### PR TITLE
V13.03

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,19 +1,15 @@
-# .github/workflows/release.yml
-name: Release About Time v13
+name: Release About Time
 
 on:
-  # 1) Manual trigger for one-click releases
+  push:
+    tags:
+      - "v*.*.*"             # e.g., v13.0.4
   workflow_dispatch:
     inputs:
-      force:
-        description: "Force re-release (skip existing tag checks)"
+      tag:
+        description: "Tag to release (e.g. v13.0.4). Leave blank to auto-detect."
         required: false
-        default: "false"
-  # 2) Auto-release when module.json version is bumped on main
-  push:
-    branches: [ "main" ]
-    paths:
-      - "module.json"
+        default: ""
 
 permissions:
   contents: write
@@ -22,8 +18,7 @@ jobs:
   build-and-release:
     runs-on: ubuntu-latest
     env:
-      GIT_USER_NAME: "github-actions[bot]"
-      GIT_USER_EMAIL: "41898282+github-actions[bot]@users.noreply.github.com"
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - name: Checkout
@@ -31,121 +26,77 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Ensure jq & zip are available
+      - name: Ensure jq & zip & gh
         run: |
-          sudo apt-get update
+          sudo apt-get update -y
           sudo apt-get install -y jq zip
 
-      - name: Read manifest values
-        id: manifest
+      - name: Determine TAG and VERSION
+        id: detect
         run: |
           set -euo pipefail
-          VERSION=$(jq -r '.version' module.json)
-          ID=$(jq -r '.id' module.json)
-          TITLE=$(jq -r '.title' module.json)
+          REF_NAME="${GITHUB_REF_NAME:-}"            # e.g., v13.0.4 or 13.0.4 or main
+          INPUT_TAG="${{ github.event.inputs.tag || '' }}"
+          VERSION_JSON=$(jq -r '.version' module.json)
+          # Prefer: pushed tag → input tag → branch (if looks like 13.0.4 and no tag exists) → v<module.json.version>
+          if [[ "$REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            TAG="$REF_NAME"
+          elif [[ "$INPUT_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            TAG="$INPUT_TAG"
+          else
+            # If current ref is a version-like branch (e.g., 13.0.4) AND tag doesn't exist, we'll create it later
+            if [[ "$REF_NAME" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              TAG="v${REF_NAME}"
+            else
+              TAG="v${VERSION_JSON}"
+            fi
+          fi
+          VERSION="${TAG#v}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "id=$ID" >> "$GITHUB_OUTPUT"
-          echo "title=$TITLE" >> "$GITHUB_OUTPUT"
+          echo "ref_name=$REF_NAME" >> "$GITHUB_OUTPUT"
+          echo "Using TAG=$TAG VERSION=$VERSION REF=$REF_NAME"
 
-      - name: Basic schema checks
+      - name: Create tag if missing (from version-like branch)
         run: |
           set -euo pipefail
-          jq -e '
-            (.id | strings and length>0 and test("^[a-z0-9-]+$"))
-            and (.title | strings and length>0)
-            and (.version | strings and test("^[0-9]+\\.[0-9]+\\.[0-9]+$"))
-            and (.compatibility.minimum | strings)
-            and (.compatibility.verified | strings)
-            and (.compatibility.maximum | strings)
-            and (.esmodules | type=="array" and length>=1 and index("about-time.js") != null and index("vars.js") != null)
-            and (.languages | type=="array" and length>=1)
-            and (.socket | type=="boolean")
-            and (.url | strings and length>0)
-            and (.manifest | strings and length>0)
-            and (.download | strings and length>0)
-          ' module.json >/dev/null
-
-      - name: Validate module id
-        run: |
-          set -euo pipefail
-          ID="${{ steps.manifest.outputs.id }}"
-          if [ "$ID" != "about-time-v13" ]; then
-            echo "module.json id must be 'about-time-v13' but is '$ID'"
-            exit 1
+          TAG="${{ steps.detect.outputs.tag }}"
+          REF="${{ steps.detect.outputs.ref_name }}"
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists."
+          else
+            if [[ "$REF" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "Creating tag $TAG from branch $REF"
+              git tag -a "$TAG" -m "Release $TAG"
+              git push origin "$TAG"
+            else
+              echo "No version-like branch; not creating a new tag."
+            fi
           fi
 
-      - name: Prepare expected tag & download URL
-        id: calc
-        run: |
-          set -euo pipefail
-          VERSION="${{ steps.manifest.outputs.version }}"
-          TAG="v${VERSION}"
-          REPO="${GITHUB_REPOSITORY}"
-          EXPECT_DL="https://github.com/${REPO}/releases/download/${TAG}/about-time-v${VERSION}.zip"
-          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-          echo "expect_dl=$EXPECT_DL" >> "$GITHUB_OUTPUT"
-
-      - name: Patch module.json download field if needed
+      - name: Patch module.json (download only)
         id: patch
         run: |
           set -euo pipefail
-          EXPECT_DL="${{ steps.calc.outputs.expect_dl }}"
+          REPO="${GITHUB_REPOSITORY}"
+          TAG="${{ steps.detect.outputs.tag }}"
+          VERSION="${{ steps.detect.outputs.version }}"
+          ZIPNAME="about-time-v${VERSION}.zip"
+          EXPECT_DL="https://github.com/${REPO}/releases/download/${TAG}/${ZIPNAME}"
           CUR_DL=$(jq -r '.download' module.json)
           if [ "$CUR_DL" != "$EXPECT_DL" ]; then
-            echo "Patching module.json download to $EXPECT_DL"
+            echo "Updating download URL -> $EXPECT_DL"
             tmp=$(mktemp)
             jq --arg dl "$EXPECT_DL" '.download = $dl' module.json > "$tmp"
             mv "$tmp" module.json
-            echo "patched=true" >> "$GITHUB_OUTPUT"
           else
-            echo "No patch needed."
-            echo "patched=false" >> "$GITHUB_OUTPUT"
+            echo "Download URL already correct."
           fi
+          echo "zipname=$ZIPNAME" >> "$GITHUB_OUTPUT"
 
-      - name: Commit patched module.json (if changed)
-        if: steps.patch.outputs.patched == 'true'
+      - name: Basic checks
         run: |
           set -euo pipefail
-          git config user.name  "${GIT_USER_NAME}"
-          git config user.email "${GIT_USER_EMAIL}"
-          git add module.json
-          git commit -m "chore(release): set download URL for ${{ steps.calc.outputs.tag }}"
-          git push
-
-      - name: Create tag if missing
-        id: tag
-        run: |
-          set -euo pipefail
-          TAG="${{ steps.calc.outputs.tag }}"
-          FORCE="${{ github.event.inputs.force || 'false' }}"
-          if git rev-parse "$TAG" >/dev/null 2>&1 && [ "$FORCE" != "true" ]; then
-            echo "Tag $TAG already exists; continuing to build/release."
-            echo "created=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          git config user.name  "${GIT_USER_NAME}"
-          git config user.email "${GIT_USER_EMAIL}"
-          git tag -a "$TAG" -m "Release $TAG"
-          git push origin "$TAG"
-          echo "created=true" >> "$GITHUB_OUTPUT"
-
-      - name: Verify esmodules exist
-        run: |
-          set -euo pipefail
-          jq -r '.esmodules[]' module.json > esmodules.txt
-          while IFS= read -r f; do
-            echo "Checking esmodule: $f"
-            test -f "$f"
-          done < esmodules.txt
-
-      - name: Create zip
-        id: zip
-        run: |
-          set -euo pipefail
-          VERSION="${{ steps.manifest.outputs.version }}"
-          ZIP="about-time-v${VERSION}.zip"
-
-          # required roots
           test -f module.json
           test -f about-time.js
           test -f vars.js
@@ -153,31 +104,58 @@ jobs:
           test -d templates
           test -d lang
 
-          # optional docs
+      - name: Build ZIP
+        id: zip
+        run: |
+          set -euo pipefail
+          ZIP="${{ steps.patch.outputs.zipname }}"
           DOCS=()
           [ -f README.md ] && DOCS+=("README.md")
           [ -f LICENSE ] && DOCS+=("LICENSE")
           [ -f LICENSE.md ] && DOCS+=("LICENSE.md")
+          zip -r "$ZIP" module.json about-time.js vars.js module templates lang "${DOCS[@]}" >/dev/null
+          echo "zip=$ZIP" >> "$GITHUB_OUTPUT"
 
-          zip -r "$ZIP" \
-            module.json about-time.js vars.js \
-            module templates lang "${DOCS[@]}" \
-            >/dev/null
-          echo "zipname=$ZIP" >> "$GITHUB_OUTPUT"
+      - name: Check if release exists
+        id: rel
+        run: |
+          set -euo pipefail
+          TAG="${{ steps.detect.outputs.tag }}"
+          API="https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}"
+          if gh api -H "Accept: application/vnd.github+json" "$API" >/tmp/release.json 2>/dev/null; then
+            echo "exists=true"  >> "$GITHUB_OUTPUT"
+            echo "rel_id=$(jq -r '.id' /tmp/release.json)" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
 
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: about-time-dist
-          path: ${{ steps.zip.outputs.zipname }}
+      - name: Delete same-named assets if release exists
+        if: steps.rel.outputs.exists == 'true'
+        run: |
+          set -euo pipefail
+          REL_ID="${{ steps.rel.outputs.rel_id }}"
+          ZIP="${{ steps.zip.outputs.zip }}"
+          gh api -H "Accept: application/vnd.github+json" "/repos/${GITHUB_REPOSITORY}/releases/${REL_ID}/assets" >/tmp/assets.json
+          for NAME in "$ZIP" "module.json"; do
+            ASSET_ID=$(jq -r --arg NAME "$NAME" '.[] | select(.name==$NAME) | .id' /tmp/assets.json || true)
+            if [ -n "$ASSET_ID" ] && [ "$ASSET_ID" != "null" ]; then
+              echo "Deleting existing asset $ASSET_ID ($NAME)"
+              gh api -X DELETE -H "Accept: application/vnd.github+json" "/repos/${GITHUB_REPOSITORY}/releases/assets/${ASSET_ID}"
+            else
+              echo "No existing asset named $NAME to delete."
+            fi
+          done
 
-      - name: Create GitHub Release
+      - name: Create or Update Release and upload assets
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ steps.calc.outputs.tag }}
-          name: About Time ${{ steps.calc.outputs.tag }}
+          tag_name: ${{ steps.detect.outputs.tag }}
+          name: ${{ steps.detect.outputs.tag }}          # You will edit the title & notes manually
           draft: false
           prerelease: false
-          files: ${{ steps.zip.outputs.zipname }}
+          files: |
+            ${{ steps.zip.outputs.zip }}
+            module.json
+          fail_on_unmatched_files: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Key Methods
 | `notifyIn(interval, eventName, ...args)`    | Trigger a Foundry hook after an interval.     |
 | `notifyEvery(interval, eventName, ...args)` | Trigger a Foundry hook repeatedly.            |
 | `chatQueue(options)`                        | Print the event queue to chat.                |
-| `gclearTimeout(uid)`                        | Cancel a scheduled event.                     |
+| `clearTimeout(uid)`                         | Cancel a scheduled event.                     |
 | `DTNow()`                                   | Get current world time (seconds).             |
 
 ## 🗣 /at Chat Command
@@ -66,11 +66,11 @@ Available in chat:
 - `/at in <duration> <message>` — schedule one-time reminder  
 - `/at every <duration> <message>` — schedule repeating reminder  
 
-**Duration shorthand:** supports mixed units — `1h30m`, `2d 4h`, `45m10s`, or plain seconds.  
+**Duration shorthand:** supports mixed units — `1h30m`, `2d 4h`, `45m10s`, or plain seconds. (plain number = seconds) 
 Examples:
 - /at in 10m Check the stew
 - /at every 1h Random Encounter
-- /at stop abc123(uid)
+- /at stop abc123
 - /at clear
 - /at in 10 Time for a coffee break!
 
@@ -132,23 +132,23 @@ MIT — see LICENSE file.
 ```js
 game.abouttime.reminderIn({ minutes: 1 }, "One minute has passed!");
 ```
-2. Repeat every 10 seconds
+**2. Repeat every 10 seconds**
 ```js
 game.abouttime.doEvery({ seconds: 10 }, () => {
   ui.notifications.info("10 seconds passed!");
 });
 ```
-4. Run a macro at 6:00 AM game time
+**3. Run a macro at 6:00 AM game time**
 ```js
 game.abouttime.doAt({ hour: 6, minute: 0 }, () => {
   ChatMessage.create({ content: "Good morning!" });
 });
 ```
-5. Print the queue to chat
+**4. Print the queue to chat**
 ```js
 game.abouttime.chatQueue({ showArgs: true, showUid: true, showDate: true, gmOnly: false });
 ```
-6. Cancel an event
+**5. Cancel an event**
 ```js
 let uid = game.abouttime.doIn({ seconds: 30 }, () => {
   console.log("This will be cancelled!");

--- a/README.md
+++ b/README.md
@@ -60,14 +60,19 @@ Key Methods
 ## 🗣 /at Chat Command
 Available in chat:
 
-/at queue — Show current scheduled events
+- `/at queue` or `/at list` — show the queue  
+- `/at clear` — clear the entire queue  
+- `/at stop <uid>` — cancel a specific event by its UID  
+- `/at in <duration> <message>` — schedule one-time reminder  
+- `/at every <duration> <message>` — schedule repeating reminder  
 
-/at in <seconds> <message> — Schedule a one-time reminder
-
-/at every <seconds> <message> — Schedule a repeating reminder
-
-Example:
-/at in 10 Time for a coffee break!
+**Duration shorthand:** supports mixed units — `1h30m`, `2d 4h`, `45m10s`, or plain seconds.  
+Examples:
+- /at in 10m Check the stew
+- /at every 1h Random Encounter
+- /at stop abc123(uid)
+- /at clear
+- /at in 10 Time for a coffee break!
 
 ## ⏱ Examples
 These examples work with or without Simple Calendar.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# About Time (v13.0.2)
+# About Time (v13.0.3)
 
 **About Time** is a timekeeping and event scheduling utility for Foundry VTT.  
 It works with **Simple Calendar** (if installed) or falls back to Foundry’s core time system.  

--- a/about-time.js
+++ b/about-time.js
@@ -1,3 +1,6 @@
+// about-time.js
+// About Time v13.0.1 entrypoint (SC optional, FVTT v13+)
+
 import { registerSettings, MODULE_ID } from './module/settings.js';
 import { preloadTemplates } from './module/preloadTemplates.js';
 import { ElapsedTime } from './module/ElapsedTime.js';
@@ -13,43 +16,62 @@ function isSCActive() {
 }
 
 export let simpleCalendar;
+
+/** Authoritative world time (seconds). */
 export function DTNow() {
   return game.time.worldTime;
 }
 
+/* ------------------------------------ */
+/* Init                                 */
+/* ------------------------------------ */
 Hooks.once('init', async () => {
   console.log(`${MODULE_ID} | Initializing`);
   registerSettings();
-  // await preloadTemplates(); // enable if/when you use templates in UI
+  // await preloadTemplates(); // enable when UI needs templates
 });
 
 let operations;
 export const calendars = {};
 
+/* ------------------------------------ */
+/* Setup                                */
+/* ------------------------------------ */
 Hooks.once('setup', () => {
   operations = {
+    // State
     isMaster: () => PseudoClock.isMaster,
     isRunning: PseudoClock.isRunning,
 
+    // Scheduling
     doAt: ElapsedTime.doAt,
     doIn: ElapsedTime.doIn,
     doEvery: ElapsedTime.doEvery,
     doAtEvery: ElapsedTime.doAtEvery,
+
+    // Reminders
     reminderAt: ElapsedTime.reminderAt,
     reminderIn: ElapsedTime.reminderIn,
     reminderEvery: ElapsedTime.reminderEvery,
     reminderAtEvery: ElapsedTime.reminderAtEvery,
+
+    // Notifications (hooks)
     notifyAt: ElapsedTime.notifyAt,
     notifyIn: ElapsedTime.notifyIn,
     notifyEvery: ElapsedTime.notifyEvery,
     notifyAtEvery: ElapsedTime.notifyAtEvery,
 
+    // Queue management
     clearTimeout: ElapsedTime.gclearTimeout,
     getTimeString: ElapsedTime.currentTimeString,
     getTime: ElapsedTime.currentTimeString,
     queue: ElapsedTime.showQueue,
     chatQueue: ElapsedTime.chatQueue,
+    flushQueue: ElapsedTime._flushQueue,
+    reset: ElapsedTime._initialize,
+    status: ElapsedTime.status,
 
+    // Classes
     ElapsedTime,
     DTM: DTMod,
     DTC: DTCalc,
@@ -57,43 +79,55 @@ Hooks.once('setup', () => {
     calendars,
     DTNow,
 
+    // Internals
     _notifyEvent: PseudoClock.notifyEvent,
-
-    startRunning: () => { const api = globalThis.SimpleCalendar?.api; if (api?.startClock) api.startClock(); else console.warn('SC API not available'); },
-    stopRunning:  () => { const api = globalThis.SimpleCalendar?.api; if (api?.stopClock)  api.stopClock();  else console.warn('SC API not available'); },
-
     mutiny: PseudoClock.mutiny,
-    advanceClock: ElapsedTime.advanceClock,
-    advanceTime: ElapsedTime.advanceTime,
-    setClock: PseudoClock.setClock,
-    setTime: ElapsedTime.setTime,
-    setAbsolute: ElapsedTime.setAbsolute,
-    setDateTime: ElapsedTime.setDateTime,
+    advanceClock: ElapsedTime.advanceClock, // deprecated
+    advanceTime: ElapsedTime.advanceTime,   // deprecated
+    setClock: PseudoClock.setClock,         // deprecated
+    setTime: ElapsedTime.setTime,           // deprecated
+    setAbsolute: ElapsedTime.setAbsolute,   // deprecated
+    setDateTime: ElapsedTime.setDateTime,   // deprecated
+    _save: ElapsedTime._save,
+    _load: ElapsedTime._load,
 
-    flushQueue: ElapsedTime._flushQueue,
-    reset: ElapsedTime._initialize,
-    resetCombats: () => console.error(`${MODULE_ID} | not supported`),
-    status: ElapsedTime.status,
-    pc: PseudoClock,
+    // SC helpers (soft integration)
+    startRunning: () => {
+      const api = globalThis.SimpleCalendar?.api;
+      if (api?.startClock) api.startClock();
+      else console.warn(`${MODULE_ID} | Simple Calendar API not available`);
+    },
+    stopRunning: () => {
+      const api = globalThis.SimpleCalendar?.api;
+      if (api?.stopClock) api.stopClock();
+      else console.warn(`${MODULE_ID} | Simple Calendar API not available`);
+    },
+    showClock: () => {
+      const api = globalThis.SimpleCalendar?.api;
+      if (api?.showCalendar) api.showCalendar(null, true);
+      else console.warn(`${MODULE_ID} | Simple Calendar API not available`);
+    },
+    showCalendar: () => {
+      const api = globalThis.SimpleCalendar?.api;
+      if (api?.showCalendar) api.showCalendar();
+      else console.warn(`${MODULE_ID} | Simple Calendar API not available`);
+    },
 
-    showClock: () => { const api = globalThis.SimpleCalendar?.api; if (api?.showCalendar) api.showCalendar(null, true); else console.warn('SC API not available'); },
-    showCalendar: () => { const api = globalThis.SimpleCalendar?.api; if (api?.showCalendar) api.showCalendar(); else console.warn('SC API not available'); },
-
+    /** Delete by UUID (v13-safe). */
     async deleteUuid(uuid) {
       const thing = foundry?.utils?.fromUuidSync?.(uuid) ?? globalThis.fromUuidSync?.(uuid);
       if (!thing) return console.warn(`${MODULE_ID} | deleteUuid: could not resolve uuid ${uuid}`);
       if (typeof thing.delete === 'function') await thing.delete();
       else console.warn(`${MODULE_ID} | deleteUuid: resolved object has no delete()`, thing);
-    },
-
-    _save: ElapsedTime._save,
-    _load: ElapsedTime._load,
+    }
   };
 
   game.abouttime = operations;
+
+  // Legacy proxies with warning
   const GametimeHandler = {
     get(target, prop, receiver) {
-      console.warn(`${MODULE_ID} | Gametime.${String(prop)} is deprecated. Use abouttime.${String(prop)}.`);
+      console.warn(`${MODULE_ID} | game.Gametime.${String(prop)} is deprecated. Use game.abouttime.${String(prop)}.`);
       return Reflect.get(target, prop, receiver);
     }
   };
@@ -105,35 +139,97 @@ Hooks.once('setup', () => {
   window.Gametime = new Proxy(operations, GametimeHandler);
 });
 
-// /at chat command: "/at queue", "/at in <seconds> <message>", "/at every <seconds> <message>"
-Hooks.on('chatMessage', (log, message, chatData) => {
+/* ------------------------------------ */
+/* /at chat command                     */
+/* ------------------------------------ */
+
+/** Parse mixed durations: "1h30m", "2d 4h 10m", "45m10s", or plain "90". */
+function parseMixedDuration(input) {
+  if (!input || typeof input !== 'string') return 0;
+  const cleaned = input.trim();
+  if (/^\d+$/.test(cleaned)) return Number(cleaned);
+  const regex = /(\d+)\s*(d|h|m|s)?/gi;
+  let total = 0, m;
+  while ((m = regex.exec(cleaned)) !== null) {
+    const val = Number(m[1]);
+    const unit = (m[2] || 's').toLowerCase();
+    switch (unit) {
+      case 'd': total += val * 86400; break;
+      case 'h': total += val * 3600; break;
+      case 'm': total += val * 60; break;
+      case 's': default: total += val; break;
+    }
+  }
+  return total;
+}
+
+Hooks.on('chatMessage', (log, message /*, chatData */) => {
   if (!message?.trim()?.toLowerCase().startsWith('/at')) return;
   const parts = message.trim().split(/\s+/);
+  const sub = (parts[1] || '').toLowerCase();
+
   // /at queue
-  if (parts[1] === 'queue') {
+  if (sub === 'queue' || sub === 'list') {
     game.abouttime.chatQueue({ showArgs: true, showUid: true, showDate: true, gmOnly: false });
     return false;
   }
-  // /at in 5 Hello world
-  if (parts[1] === 'in' && !isNaN(Number(parts[2]))) {
-    const secs = Number(parts[2]);
-    const text = parts.slice(3).join(' ') || `Reminder in ${secs}s`;
-    game.abouttime.reminderIn({ seconds: secs }, text);
-    ui.notifications?.info?.(`[About Time] scheduled in ${secs}s: ${text}`);
+
+  // /at clear
+  if (sub === 'clear') {
+    game.abouttime.flushQueue();
+    ui.notifications?.info?.('[About Time] queue cleared');
     return false;
   }
-  // /at every 10 Ping!
-  if (parts[1] === 'every' && !isNaN(Number(parts[2]))) {
-    const secs = Number(parts[2]);
-    const text = parts.slice(3).join(' ') || `Repeating every ${secs}s`;
-    game.abouttime.reminderEvery({ seconds: secs }, text);
-    ui.notifications?.info?.(`[About Time] repeating every ${secs}s: ${text}`);
+
+  // /at stop <uid>
+  if (sub === 'stop' && parts[2]) {
+    const uid = parts[2];
+    const removed = game.abouttime.clearTimeout(uid);
+    if (removed) {
+      ui.notifications?.info?.(`[About Time] cancelled ${uid}`);
+      ChatMessage.create({ content: `[About Time] Cancelled event ${uid}` });
+    } else {
+      ui.notifications?.warn?.(`[About Time] no event with uid ${uid}`);
+    }
     return false;
   }
-  ui.notifications?.warn?.('Usage: /at queue | /at in <seconds> <message> | /at every <seconds> <message>');
+
+  // /at in <duration> <message>
+  if (sub === 'in' && parts[2]) {
+    const seconds = parseMixedDuration(parts[2]);
+    const text = parts.slice(3).join(' ') || `Reminder in ${seconds}s`;
+    if (!seconds || seconds < 0) {
+      ui.notifications?.warn?.('Usage: /at in <duration> <message>. Example: /at in 1h30m Take a break');
+      return false;
+    }
+    game.abouttime.reminderIn({ seconds }, text);
+    ui.notifications?.info?.(`[About Time] scheduled in ${seconds}s: ${text}`);
+    return false;
+  }
+
+  // /at every <duration> <message>
+  if (sub === 'every' && parts[2]) {
+    const seconds = parseMixedDuration(parts[2]);
+    const text = parts.slice(3).join(' ') || `Repeating every ${seconds}s`;
+    if (!seconds || seconds < 0) {
+      ui.notifications?.warn?.('Usage: /at every <duration> <message>. Example: /at every 30s Heartbeat');
+      return false;
+    }
+    game.abouttime.reminderEvery({ seconds }, text);
+    ui.notifications?.info?.(`[About Time] repeating every ${seconds}s: ${text}`);
+    return false;
+  }
+
+  ui.notifications?.warn?.(
+    'Usage: /at queue | /at clear | /at stop <uid> | /at in <duration> <message> | /at every <duration> <message>\n' +
+    'Examples: /at in 10m Check the stew | /at every 1h Random Encounter | /at stop abc123'
+  );
   return false;
 });
 
+/* ------------------------------------ */
+/* Ready                                */
+/* ------------------------------------ */
 Hooks.once('ready', () => {
   if (!isSCActive()) console.warn(`${MODULE_ID} | Simple Calendar not loaded (optional)`);
   PseudoClock.init();

--- a/module/ElapsedTime.js
+++ b/module/ElapsedTime.js
@@ -212,9 +212,18 @@ export class ElapsedTime {
           await qe._handler(...qe._args);
         }
         if (qe._recurring) {
-          const seconds = globalThis.SimpleCalendar?.api?.timestampPlusInterval?.(qe._time, qe._increment);
+          /*const seconds = globalThis.SimpleCalendar?.api?.timestampPlusInterval?.(qe._time, qe._increment);
           if (seconds > qe._time) {
-            qe._time = seconds;
+            qe._time = seconds;*/
+        const scAdd = globalThis.SimpleCalendar?.api?.timestampPlusInterval;
+        const next = scAdd
+          ? scAdd(qe._time, qe._increment)                  // SC path
+          : (() => {                                        // fallback seconds math
+            if (typeof qe._increment === "number") return qe._time + qe._increment;
+            return qe._time + intervalToSeconds(qe._increment);
+          })();
+        if (next > qe._time) {
+          qe._time = next;
             q.add(qe);
           } else {
             console.error(`${MODULE_ID} | Recurring event reschedule rejected`, qe);

--- a/module/ElapsedTime.js
+++ b/module/ElapsedTime.js
@@ -1,3 +1,15 @@
+function intervalToSeconds(iv = {}) {
+  // safe ints; fallback for SC-off mode
+  const day = Number(iv.day ?? iv.days ?? 0);
+  const hour = Number(iv.hour ?? iv.hours ?? 0);
+  const minute = Number(iv.minute ?? iv.minutes ?? 0);
+  const second = Number(iv.second ?? iv.seconds ?? 0);
+
+  // use DTCalc.spd if available; else 24h
+  const spd = (globalThis.game?.abouttime?.DTC?.spd) ? game.abouttime.DTC.spd : 24 * 60 * 60;
+  return (day * spd) + (hour * 3600) + (minute * 60) + second;
+}
+
 import { FastPriorityQueue, Quentry } from "./FastPirorityQueue.js";
 import { PseudoClock, PseudoClockMessage, _addEvent } from "./PseudoClock.js";
 import { currentWorldTime, dateToTimestamp, intervalATtoSC, intervalSCtoAT } from "./calendar/DateTime.js";


### PR DESCRIPTION
# v13.0.3 — Queue Management Fixes & /at Command Upgrades
🚀 New Features
- Persistent repeating events — Fixed doEvery() so events repeat as intended instead of disappearing after first trigger.

## Queue control commands:

- /at stop <uid> — cancel a single scheduled event by UID.

- /at clear — instantly purge the entire event queue.

- /at queue and /at list — list all events in queue with UIDs and repeat info.

- Flexible time parsing for /at in and /at every:

- Supports mixed units: 1h30m, 2d 4h, 45m10s, 3h, 90s, etc.

- Still accepts legacy {hour:1} style for API calls/macros.

- Better feedback — Chat and notifications now clearly confirm event creation, repeats, and cancellations.

## 🛠 Improvements
- Updated macro examples to use the fixed doEvery() API.

- /at commands now work even if Simple Calendar is disabled — fallback uses Foundry core time.

- queue output includes event UIDs for easy /at stop targeting.

## 📋 Usage Examples

- /at in 10m Check the stew
- /at every 1h Random Encounter
- /at in 2d 4h Prepare the ritual
- /at stop abc123
- /at clear

## 🐛 Fixes
- Fixed bug where doEvery() behaved like doIn() (single execution).

- Guarded against missing SC API in repeating event logic.

- Removed stale queue entries more reliably.